### PR TITLE
Coroutine Callback Lifetime Patch

### DIFF
--- a/include/BidirectionalCoroutine.hpp
+++ b/include/BidirectionalCoroutine.hpp
@@ -34,7 +34,7 @@ namespace com {
 				template<class StackAlloc> struct _CoroutineContext {
 					template<class Coro, class F>
 					static boost::context::continuation startCoroutine(Coro& bdc, F & f, size_t stackSize){
-						return boost::context::callcc(std::allocator_arg, StackAlloc(stackSize), [&](boost::context::continuation && c){
+						return boost::context::callcc(std::allocator_arg, StackAlloc(stackSize), [&bdc,f](boost::context::continuation && c){
 							typename Coro::Yield yield(bdc, std::move(c));
 							FinishCoroutine<Coro>::apply(yield,f);
 							return std::move(yield.to_);


### PR DESCRIPTION
Capture the callback by value so it is stored on the stack of the coroutine.
Capturing the callback by reference can result in errors if the lifetime of the callback is shorter than the lifetime of the coroutine.

For example, if the callback is a capturing lambda, then the values of variables can become erroneous.